### PR TITLE
Search menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # spotify_artist
 
 Mobile app creation for searching and view Spotify Artists using Flutter. Created by Armaan Pahwa
+This project has only been run and test on Andriod, as it was developed on a Windows OS.
+Installing Swift/Xcode on a copy of this repo _SHOULD_ allow for iOS compatability, but it is currently untested.
 
 ## Current Functionality
 - Home page
 - API Authentication
+- Artist objects
+- Search Menu Results
 
 ## Current Development
-- Search menu functionality
-- Create Artist object
+- Search menu suggestions
 
 ## To-Do
 - Create Splash Page
@@ -17,7 +20,7 @@ Mobile app creation for searching and view Spotify Artists using Flutter. Create
 - UI/UX refactoring
 
 ## How to Use
-- In order to use this application, you must ensure that [Flutter](https://flutter.dev/) and [Andriod Studio](https://developer.android.com/studio/) are installed.
+- In order to use this application from the source code, you must ensure that [Flutter](https://flutter.dev/) and [Andriod Studio](https://developer.android.com/studio/) are installed.
 - Once installed, ensure all packages listed below are installed.
 - Open this in any IDE and ensure there is a connection to an Andriod device or Andriod emulator.
 - Run the `main.dart` file using `Dart and Flutter` and interact with application on connected device.
@@ -34,3 +37,4 @@ Packages can be installed through running the `flutter pub get` as long as packa
 ## References
 - [Flutter documentation](https://flutter.dev/docs)
 - [Flutter examples](https://flutter.dev/docs/cookbook)
+- [TL Dev Tech](https://www.tldevtech.com/flutter-futurebuilder-with-listview-example/): Flutter FutureBuilder with ListView

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # spotify_artist
 
-Mobile app creation for searching and view Spotify Artists using Flutter. Created by Armaan Pahwa
+Mobile app creation for searching and view Spotify Artists using Flutter. Created by Armaan Pahwa. 
 This project has only been run and test on Andriod, as it was developed on a Windows OS.
-Installing Swift/Xcode on a copy of this repo _SHOULD_ allow for iOS compatability, but it is currently untested.
+Installing Swift/Xcode on a copy of this repo _SHOULD_ allow for seamless iOS compatability, but it is currently untested.
 
 ## Current Functionality
 - Home page
@@ -11,13 +11,11 @@ Installing Swift/Xcode on a copy of this repo _SHOULD_ allow for iOS compatabili
 - Search Menu Results
 
 ## Current Development
-- Search menu suggestions
+- Search menu past searches
 
 ## To-Do
-- Create Splash Page
-- Create Artist view page
-- Quality of life changes
-- UI/UX refactoring
+- Create Artist information page
+- Home Page refactoring
 
 ## How to Use
 - In order to use this application from the source code, you must ensure that [Flutter](https://flutter.dev/) and [Andriod Studio](https://developer.android.com/studio/) are installed.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Installing Swift/Xcode on a copy of this repo _SHOULD_ allow for seamless iOS co
 - API Authentication
 - Artist objects
 - Search Menu Results
+- Search menu past searches (Resets on return to home page)
 
 ## Current Development
-- Search menu past searches
+- Create Artist information page
 
 ## To-Do
-- Create Artist information page
 - Home Page refactoring
 
 ## How to Use

--- a/lib/data-models/artist.dart
+++ b/lib/data-models/artist.dart
@@ -1,14 +1,26 @@
 class Artist {
   String name;
+  int followers;
+  String imageUrl;
 
-  Artist(this.name);
+  Artist(this.name, this.followers, this.imageUrl);
 
   factory Artist.fromJson(Map json) {
-    //Frame for artist factory. To be edited later.
-    return Artist(json['name']);
+    String url = json['images'].isEmpty
+        ? 'https://picsum.photos/id/119/200/200'
+        : json['images'][0]['url'];
+    return Artist(json['name'], json['followers']['total'], url);
   }
 
   String getArtistName() {
     return this.name;
+  }
+
+  int getArtistFollowers() {
+    return this.followers;
+  }
+
+  String getArtistImageUrl() {
+    return this.imageUrl;
   }
 }

--- a/lib/home page.dart
+++ b/lib/home page.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'package:spotify_artist/api-connection/spotify_auth.dart';
+import 'package:spotify_artist/api-connection/authorization_token.dart';
+import 'package:spotify_artist/api-connection/spotify_api_search.dart';
+import 'package:spotify_artist/data-models/artist.dart';
+
 class SpotifyArtistHomePage extends StatefulWidget {
   SpotifyArtistHomePage({Key key, this.title}) : super(key: key);
 
@@ -35,22 +40,19 @@ class _SpotifyArtistHomePage extends State<SpotifyArtistHomePage> {
 }
 
 class DataSearch extends SearchDelegate<String> {
-  var entries = [
-    "Entry 1",
-    "Entry 2",
-    "Entry 3",
-    "Entry 4",
-    "Entry 5",
-    "Artist 1",
-    "Artist 2",
-    "Artist 3",
-  ];
-
   var suggestedEntries = [
     "Entry 1",
     "Entry 2",
     "Artist 1",
   ];
+
+  Future<List> _buildAPIResults() async {
+    AuthorizationToken authorizationToken =
+        await SpotifyAuth.getAuthenticationToken();
+    var artistList =
+        await SpotifyApiSearch.getArtistSearchList(authorizationToken, query);
+    return artistList;
+  }
 
   //Creates the clear search query
   @override
@@ -77,18 +79,44 @@ class DataSearch extends SearchDelegate<String> {
 
   @override
   Widget buildResults(BuildContext context) {
-    final dataResults = entries.where(
-      (entry) => entry.toLowerCase().contains(query.toLowerCase()),
-    );
-
-    return ListView.builder(
-      itemBuilder: (context, index) => ListTile(
-        leading: Icon(Icons.person_search),
-        title: Text(dataResults.elementAt(index)),
-        onTap: () {},
-      ),
-      itemCount: dataResults.length,
-    );
+    if (query == "") {
+      return Center(
+        child: Text('Please enter a valid name'),
+      );
+    }
+    return FutureBuilder(
+        future: _buildAPIResults(),
+        builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            List<Widget> children = const <Widget>[
+              SizedBox(
+                child: CircularProgressIndicator(),
+                width: 60,
+                height: 60,
+              ),
+              Padding(
+                padding: EdgeInsets.only(top: 16),
+                child: Text('Search in progress...'),
+              )
+            ];
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: children,
+              ),
+            );
+          } else {
+            return ListView.builder(
+              itemBuilder: (context, index) => ListTile(
+                leading: Icon(Icons.person_search),
+                title: Text(snapshot.data[index].getArtistName()),
+                onTap: () {},
+              ),
+              itemCount: snapshot.data.length,
+            );
+          }
+        });
   }
 
   @override

--- a/lib/home page.dart
+++ b/lib/home page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:spotify_artist/api-connection/spotify_auth.dart';
 import 'package:spotify_artist/api-connection/authorization_token.dart';
 import 'package:spotify_artist/api-connection/spotify_api_search.dart';
-import 'package:spotify_artist/data-models/artist.dart';
 
 class SpotifyArtistHomePage extends StatefulWidget {
   SpotifyArtistHomePage({Key key, this.title}) : super(key: key);
@@ -81,7 +80,7 @@ class DataSearch extends SearchDelegate<String> {
   Widget buildResults(BuildContext context) {
     if (query == "") {
       return Center(
-        child: Text('Please enter a valid name'),
+        child: Text('Please enter an artist name above'),
       );
     }
     return FutureBuilder(
@@ -108,10 +107,14 @@ class DataSearch extends SearchDelegate<String> {
             );
           } else {
             return ListView.builder(
-              itemBuilder: (context, index) => ListTile(
-                leading: Icon(Icons.person_search),
-                title: Text(snapshot.data[index].getArtistName()),
-                onTap: () {},
+              itemBuilder: (context, index) => Padding(
+                padding: EdgeInsets.only(top: 8, bottom: 8),
+                child: ListTile(
+                  leading:
+                      Image.network(snapshot.data[index].getArtistImageUrl()),
+                  title: Text(snapshot.data[index].getArtistName()),
+                  onTap: () {},
+                ),
               ),
               itemCount: snapshot.data.length,
             );

--- a/lib/home page.dart
+++ b/lib/home page.dart
@@ -40,9 +40,7 @@ class _SpotifyArtistHomePage extends State<SpotifyArtistHomePage> {
 
 class DataSearch extends SearchDelegate<String> {
   var suggestedEntries = [
-    "Entry 1",
-    "Entry 2",
-    "Artist 1",
+    "John Mayer",
   ];
 
   Future<List> _buildAPIResults() async {
@@ -78,11 +76,15 @@ class DataSearch extends SearchDelegate<String> {
 
   @override
   Widget buildResults(BuildContext context) {
+    query = query.trim();
     if (query == "") {
       return Center(
         child: Text('Please enter an artist name above'),
       );
     }
+
+    if (!suggestedEntries.contains(query)) suggestedEntries.add(query);
+
     return FutureBuilder(
         future: _buildAPIResults(),
         builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
@@ -110,8 +112,11 @@ class DataSearch extends SearchDelegate<String> {
               itemBuilder: (context, index) => Padding(
                 padding: EdgeInsets.only(top: 8, bottom: 8),
                 child: ListTile(
-                  leading:
-                      Image.network(snapshot.data[index].getArtistImageUrl()),
+                  leading: ClipRRect(
+                    borderRadius: BorderRadius.circular(300),
+                    child:
+                        Image.network(snapshot.data[index].getArtistImageUrl()),
+                  ),
                   title: Text(snapshot.data[index].getArtistName()),
                   onTap: () {},
                 ),
@@ -130,9 +135,20 @@ class DataSearch extends SearchDelegate<String> {
       itemBuilder: (context, index) => ListTile(
         leading: Icon(Icons.update),
         title: Text(suggestionList[index]),
-        onTap: () {},
+        onTap: () {
+          query = suggestionList[index];
+        },
       ),
       itemCount: suggestionList.length,
     );
+  }
+
+  @override
+  ThemeData appBarTheme(BuildContext buildContext) {
+    assert(buildContext != null);
+    final ThemeData theme = Theme.of(buildContext);
+    assert(theme != null);
+    return ThemeData(
+        primaryColor: Color(0xFF1DB954), brightness: Brightness.dark);
   }
 }


### PR DESCRIPTION
Full search menu building complete. Ability to search for artists (with invalid name detection / trimming) and see a result of spotify artist search with images included. Artist object is created with name, followers, and url for display on Artist information page. Unique and valid searches are saved in recent search history which clears on return to home page. 